### PR TITLE
object storage interface refactored

### DIFF
--- a/cads_catalogue/form_manager.py
+++ b/cads_catalogue/form_manager.py
@@ -138,7 +138,6 @@ def store_form_by_data(
             storage_settings.object_storage_url,
             bucket_name=storage_settings.catalogue_bucket,
             subpath=subpath,
-            force=True,
             **storage_settings.storage_kws,
         )
     finally:

--- a/cads_catalogue/layout_manager.py
+++ b/cads_catalogue/layout_manager.py
@@ -71,7 +71,6 @@ def manage_image_section(
                         storage_settings.object_storage_url,
                         bucket_name=storage_settings.catalogue_bucket,
                         subpath=subpath,
-                        force=True,
                         **storage_settings.storage_kws,
                     )
                     # update cache of the upload urls
@@ -345,7 +344,6 @@ def store_layout_by_data(
             storage_settings.object_storage_url,
             bucket_name=storage_settings.catalogue_bucket,
             subpath=subpath,
-            force=True,
             **storage_settings.storage_kws,
         )
     finally:

--- a/cads_catalogue/licence_manager.py
+++ b/cads_catalogue/licence_manager.py
@@ -85,7 +85,6 @@ def licence_sync(
             storage_settings.object_storage_url,  # type: ignore
             bucket_name=storage_settings.catalogue_bucket,  # type: ignore
             subpath=subpath,
-            force=True,
             **storage_kws,
         )
         setattr(db_licence, column_name, file_url)

--- a/cads_catalogue/manager.py
+++ b/cads_catalogue/manager.py
@@ -490,7 +490,6 @@ def resource_sync(
             storage_settings.object_storage_url,
             bucket_name=storage_settings.catalogue_bucket,
             subpath=subpath,
-            force=True,
             **storage_settings.storage_kws,
         )
     dataset_query_stmt = sa.select(database.Resource).filter_by(

--- a/cads_catalogue/object_storage.py
+++ b/cads_catalogue/object_storage.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import hashlib
-import json
 import os
 import pathlib
 from typing import Any
@@ -28,76 +27,8 @@ from cads_catalogue import utils
 
 logger = structlog.get_logger(__name__)
 
-DOWNLOAD_POLICY_TEMPLATE: dict[str, Any] = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": ["s3:GetBucketLocation", "s3:ListBucket"],
-            "Effect": "Allow",
-            "Principal": {"AWS": ["*"]},
-            "Resource": ["arn:aws:s3:::%(bucket_name)s"],
-        },
-        {
-            "Action": ["s3:GetObject", "s3:GetObjectVersion"],
-            "Effect": "Allow",
-            "Principal": {"AWS": ["*"]},
-            "Resource": ["arn:aws:s3:::%(bucket_name)s/*"],
-        },
-    ],
-}
-PRIVATE_POLICY_TEMPLATE: dict[str, Any] = {}
-PUBLIC_POLICY_TEMPLATE: dict[str, Any] = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "s3:GetBucketLocation",
-                "s3:ListBucket",
-                "s3:ListBucketMultipartUploads",
-            ],
-            "Effect": "Allow",
-            "Principal": {"AWS": ["*"]},
-            "Resource": ["arn:aws:s3:::%(bucket_name)s"],
-        },
-        {
-            "Action": [
-                "s3:PutObject",
-                "s3:AbortMultipartUpload",
-                "s3:DeleteObject",
-                "s3:GetObject",
-                "s3:GetObjectVersion",
-                "s3:ListMultipartUploadParts",
-            ],
-            "Effect": "Allow",
-            "Principal": {"AWS": ["*"]},
-            "Resource": ["arn:aws:s3:::%(bucket_name)s/*"],
-        },
-    ],
-}
-UPLOAD_POLICY_TEMPLATE: dict[str, Any] = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": ["s3:GetBucketLocation", "s3:ListBucketMultipartUploads"],
-            "Effect": "Allow",
-            "Principal": {"AWS": ["*"]},
-            "Resource": ["arn:aws:s3:::%(bucket_name)s"],
-        },
-        {
-            "Action": [
-                "s3:AbortMultipartUpload",
-                "s3:DeleteObject",
-                "s3:ListMultipartUploadParts",
-                "s3:PutObject",
-            ],
-            "Effect": "Allow",
-            "Principal": {"AWS": ["*"]},
-            "Resource": ["arn:aws:s3:::%(bucket_name)s/*"],
-        },
-    ],
-}
 
-CORS_CONFIG: dict[str, Any] = {
+DEFAULT_CORS_CONFIG: dict[str, Any] = {
     "CORSRules": [
         {
             "AllowedHeaders": ["Accept", "Content-Type"],
@@ -106,27 +37,6 @@ CORS_CONFIG: dict[str, Any] = {
         }
     ]
 }
-
-
-def set_bucket_policy(
-    client: boto3.session.Session.client, bucket_name: str, policy: str  # type: ignore
-) -> None:
-    """Set anonymous policy to a bucket.
-
-    Parameters
-    ----------
-    client: boto3 client object
-    bucket_name: name of the bucket
-    policy: one of 'private', 'public', 'upload', 'download'
-    """
-    policy_map = {
-        "download": DOWNLOAD_POLICY_TEMPLATE,
-        "private": PRIVATE_POLICY_TEMPLATE,
-        "public": PUBLIC_POLICY_TEMPLATE,
-        "upload": UPLOAD_POLICY_TEMPLATE,
-    }
-    policy_json = json.dumps(policy_map[policy]) % {"bucket_name": bucket_name}
-    client.put_bucket_policy(Bucket=bucket_name, Policy=policy_json)  # type: ignore
 
 
 def set_bucket_cors(
@@ -143,8 +53,85 @@ def set_bucket_cors(
     config: CORS configuration to use (default is CORS_CONFIG)
     """
     if config is None:
-        config = CORS_CONFIG
+        config = DEFAULT_CORS_CONFIG
     client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=config)  # type: ignore
+
+
+def is_bucket_read_only(client, bucket_name) -> bool:
+    """Return True if the bucket is read-only for all users."""
+    response = client.get_bucket_acl(Bucket=bucket_name)
+    try:
+        for grant in response["Grants"]:
+            grantee = grant["Grantee"]
+            if (
+                grantee["Type"] == "Group"
+                and grantee["URI"] == "http://acs.amazonaws.com/groups/global/AllUsers"
+            ):
+                return grant["Permission"] == "READ"
+    except KeyError:
+        logger.error(f"ACL of bucket {bucket_name} not parsable")
+    return False
+
+
+def is_bucket_existing(client, bucket_name) -> bool | None:
+    """Return True if the bucket exists."""
+    try:
+        client.head_bucket(Bucket=bucket_name)
+        return True
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            return False
+    return None
+
+
+def is_bucket_cors_set(client, bucket_name) -> bool | None:
+    """Return True if the bucket has CORS already set."""
+    ret_value = None
+    try:
+        client.get_bucket_cors(Bucket=bucket_name)
+        ret_value = True
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchCORSConfiguration":
+            ret_value = False
+    return ret_value
+
+
+def is_object_read_only(client, bucket, object_name):
+    """Return True if the object is stored with ACL read-only."""
+    response = client.get_object_acl(Bucket=bucket, Key=object_name)
+    try:
+        for grant in response["Grants"]:
+            grantee = grant["Grantee"]
+            if (
+                grantee["Type"] == "Group"
+                and grantee["URI"] == "http://acs.amazonaws.com/groups/global/AllUsers"
+            ):
+                return grant["Permission"] == "READ"
+    except KeyError:
+        logger.error(f"ACL of object {bucket}/{object_name} not parsable")
+    return False
+
+
+def setup_bucket(client, bucket_name) -> None:
+    """Create a public-read bucket (if not existing) and setup CORS."""
+    if not is_bucket_existing(client, bucket_name):
+        logger.info(f"creation of bucket {bucket_name}")
+        client.create_bucket(Bucket=bucket_name)
+        logger.info(f"setup ACL public-read on bucket {bucket_name}")
+        client.put_bucket_acl(ACL="public-read", Bucket=bucket_name)
+    else:
+        if not is_bucket_read_only(client, bucket_name):
+            logger.warning(f"setting ACL public-read on bucket {bucket_name}")
+            client.put_bucket_acl(ACL="public-read", Bucket=bucket_name)
+
+    if not is_bucket_cors_set(client, bucket_name):
+        logger.warning(f"setting CORS policy on bucket {bucket_name}")
+        try:
+            client.put_bucket_cors(
+                Bucket=bucket_name, CORSConfiguration=DEFAULT_CORS_CONFIG
+            )
+        except Exception:
+            logger.warning(f"unable to set CORS policy on bucket {bucket_name}")
 
 
 def store_file(
@@ -152,7 +139,6 @@ def store_file(
     object_storage_url: str,  # type: ignore
     bucket_name: str = "cads-catalogue",  # type: ignore
     subpath: str = "",
-    force: bool = False,
     use_client: Any = None,
     **storage_kws: Any,
 ) -> str:
@@ -160,8 +146,6 @@ def store_file(
 
     Store a file at `file_path` in the object storage, in the bucket `bucket_name`.
     If subpath is supplied, the file is stored in subpath/file_name.
-    If force is True, a bucket `bucket_name` is created if not existing. Note that in such case
-    the bucket has 'download' access policy for anonymous.
     Return the download URL of the stored file, relative to the object storage.
 
     Parameters
@@ -170,7 +154,6 @@ def store_file(
     object_storage_url: endpoint URL of the object storage
     bucket_name: name of the bucket to use inside the object storage
     subpath: optional folder path inside the bucket (created if not existing)
-    force: if True, force to create the bucket if not existing (default to False)
     use_client: if specified, use this client instead of a new boto3 client (used in tests)
     storage_kws: dictionary of parameters used to pass to the storage client
 
@@ -186,27 +169,9 @@ def store_file(
         client = use_client
     else:
         client = boto3.client("s3", endpoint_url=object_storage_url, **storage_kws)
+    setup_bucket(client, bucket_name)
     # NOTE: version retrieval is not supported in the public endpoint of the storage,
     # so the file is stored using a prefix including the SHA256 hash of the file content
-    try:
-        client.head_bucket(Bucket=bucket_name)
-    except botocore.exceptions.ClientError as e:
-        if e.response["Error"]["Code"] == "404":  # bucket does not exist
-            if force:
-                client.create_bucket(Bucket=bucket_name)
-                set_bucket_policy(client, bucket_name, "download")
-            else:
-                raise ValueError(
-                    "the bucket %r does not exist in the object storage" % bucket_name
-                )
-    try:
-        client.get_bucket_cors(Bucket=bucket_name)
-    except botocore.exceptions.ClientError as e:
-        if e.response["Error"]["Code"] == "NoSuchCORSConfiguration":
-            try:
-                set_bucket_cors(client, bucket_name)
-            except Exception:  # noqa:
-                logger.warning(f"unable to set CORS policy on bucket {bucket_name}")
     with open(file_path, "rb") as fp:
         data = fp.read()
         source_sha256 = hashlib.sha256(data).hexdigest()
@@ -215,15 +180,27 @@ def store_file(
     object_name = os.path.join(subpath, f"{file_prefix}_{source_sha256}{file_ext}")
     try:
         client.head_object(Bucket=bucket_name, Key=object_name)
+        logger.debug(f"file {object_name} already existing on bucket {bucket_name}")
     except botocore.exceptions.ClientError as e:
+        logger.info(f"uploading file {object_name} on bucket {bucket_name}")
         if e.response["Error"]["Code"] == "404":  # file does not exist
             client.upload_file(
                 Filename=file_path,
                 Bucket=bucket_name,
                 Key=object_name,
-                ExtraArgs={"ContentType": utils.guess_type(file_name)},
+                ExtraArgs={
+                    "ContentType": utils.guess_type(file_name),
+                    "ACL": "public-read",
+                },
             )
-
+    else:
+        if not is_object_read_only(client, bucket_name, object_name):
+            logger.info(
+                f"setting ACL read-only on object {object_name} on bucket {bucket_name}"
+            )
+            client.put_object_acl(
+                Bucket=bucket_name, Key=object_name, ACL="public-read"
+            )
     download_rel_url = "%s/%s" % (bucket_name, object_name)
     return download_rel_url
 
@@ -253,14 +230,16 @@ def delete_bucket(
     except botocore.exceptions.ClientError as e:
         if e.response["Error"]["Code"] == "BucketNotEmpty":
             if force:
-                for i, obj in enumerate(
-                    client.list_objects_v2(Bucket=bucket_name)["Contents"]
-                ):
-                    client.delete_object(Bucket=bucket_name, Key=obj["Key"])
-                    if i % 1000 == 0:
-                        logger.info(
-                            f"removed %i files from the bucket {bucket_name}..."
-                        )
+                s3 = boto3.resource(
+                    "s3", endpoint_url=object_storage_url, **storage_kws
+                )
+                bucket = s3.Bucket(bucket_name)
+                bucket_versioning = s3.BucketVersioning(bucket_name)
+                if bucket_versioning.status == "Enabled":
+                    bucket.object_versions.delete()
+                else:
+                    bucket.objects.all().delete()
+                client.delete_bucket(Bucket=bucket_name)
             else:
                 logger.error(f"bucket {bucket_name} is not empty")
     logger.info(f"bucket {bucket_name} successfully removed")

--- a/cads_catalogue/object_storage.py
+++ b/cads_catalogue/object_storage.py
@@ -182,8 +182,8 @@ def store_file(
         client.head_object(Bucket=bucket_name, Key=object_name)
         logger.debug(f"file {object_name} already existing on bucket {bucket_name}")
     except botocore.exceptions.ClientError as e:
-        logger.info(f"uploading file {object_name} on bucket {bucket_name}")
         if e.response["Error"]["Code"] == "404":  # file does not exist
+            logger.info(f"uploading file {object_name} on bucket {bucket_name}")
             client.upload_file(
                 Filename=file_path,
                 Bucket=bucket_name,

--- a/tests/test_03_object_storage.py
+++ b/tests/test_03_object_storage.py
@@ -1,5 +1,4 @@
 import hashlib
-import json
 import os
 from typing import Any
 
@@ -7,55 +6,194 @@ import botocore
 import pytest
 import pytest_mock
 
-from cads_catalogue import object_storage
+from cads_catalogue import object_storage, utils
 
 THIS_PATH = os.path.abspath(os.path.dirname(__file__))
 TESTDATA_PATH = os.path.join(THIS_PATH, "data")
 
 
+class DummyStorageObject:
+    """Simulate an object stored."""
+
+    def __init__(self, name, extra_args=None):
+        self.name = name
+        if extra_args is None:
+            extra_args = dict()
+        new_extra_args = extra_args.copy()
+        acl = new_extra_args.pop("ACL", None)
+        if acl and acl != "public-read":
+            raise NotImplementedError
+        self.acl = {
+            "ResponseMetadata": {
+                "RequestId": "a-request-id",
+                "HTTPStatusCode": 200,
+            },
+            "Grants": [
+                {
+                    "Grantee": {
+                        "Type": "Group",
+                        "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+                    },
+                    "Permission": "READ",
+                },
+            ],
+        }
+        for key, value in new_extra_args.items():
+            setattr(self, key, value)
+
+
+class DummyBucket:
+    """Simulate a bucket."""
+
+    def __init__(self, name, cors=None, acl=None):
+        self.name = name
+        self.cors = cors
+        self.acl = acl
+        self.objects = []
+
+    def __contains__(self, item):
+        names_contained = [r.name for r in self.objects]
+        return item in names_contained
+
+    def __getitem__(self, item):
+        objs_contained = {r.name: r for r in self.objects}
+        return objs_contained[item]
+
+    def __setitem__(self, key, value):
+        new_object = DummyStorageObject(name=key)
+        if key in self:
+            names_contained = [r.name for r in self.objects]
+            index = names_contained.index(key)
+            self.objects[index] = new_object
+        else:
+            self.objects.append(new_object)
+
+
 class DummyBotoClient:
+    """Simulate a boto client."""
+
     def __init__(self, resource, endpoint_url=None, **storage_kws):
         self.resource = resource
         self.endpoint_url = endpoint_url
         self.storage_kws = storage_kws
-
-    def head_bucket(self, Bucket):
-        error_response = {"Error": {"Code": "404"}}
-        error = botocore.exceptions.ClientError(error_response, "head bucket")
-        raise error
+        self.buckets = dict()
 
     def create_bucket(self, Bucket):
-        pass
+        if Bucket in self.buckets:
+            return
+        bucket_obj = DummyBucket(name=Bucket)
+        self.buckets[Bucket] = bucket_obj
 
-    def put_bucket_policy(self, Bucket, Policy):
-        pass
-
-    def head_object(self, Bucket, Key):
-        error_response = {"Error": {"Code": "404"}}
-        error = botocore.exceptions.ClientError(error_response, "head object")
-        raise error
+    def head_bucket(self, Bucket):
+        if Bucket not in self.buckets:
+            error_response = {"Error": {"Code": "404"}}
+            error = botocore.exceptions.ClientError(error_response, "head bucket")
+            raise error
 
     def get_bucket_cors(self, Bucket):
-        error_response = {"Error": {"Code": "NoSuchCORSConfiguration"}}
-        error = botocore.exceptions.ClientError(error_response, "get bucket cors")
-        raise error
+        if Bucket not in self.buckets:
+            raise ValueError("No such bucket")
+        bucket_obj = self.buckets[Bucket]
+        if not bucket_obj.cors:
+            error_response = {"Error": {"Code": "NoSuchCORSConfiguration"}}
+            error = botocore.exceptions.ClientError(error_response, "get bucket CORS")
+            raise error
+        return bucket_obj.cors
 
     def put_bucket_cors(self, Bucket, CORSConfiguration):
-        pass
+        if Bucket not in self.buckets:
+            raise ValueError("bucket doesn't exists")
+        bucket_obj = self.buckets[Bucket]
+        bucket_obj.cors = CORSConfiguration
+
+    def get_bucket_acl(self, Bucket):
+        if Bucket not in self.buckets:
+            raise ValueError("No such bucket")
+        bucket_obj = self.buckets[Bucket]
+        if not bucket_obj.acl:
+            raise ValueError("bucket doesn't have ACL")
+        return bucket_obj.acl
+
+    def put_bucket_acl(self, Bucket, ACL):
+        if Bucket not in self.buckets:
+            raise ValueError("bucket doesn't exists")
+        bucket_obj = self.buckets[Bucket]
+        if ACL != "public-read":
+            raise NotImplementedError
+        bucket_obj.acl = {
+            "ResponseMetadata": {
+                "RequestId": "a-request-id",
+                "HTTPStatusCode": 200,
+            },
+            "Grants": [
+                {
+                    "Grantee": {
+                        "Type": "Group",
+                        "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+                    },
+                    "Permission": "READ",
+                },
+            ],
+        }
+
+    def head_object(self, Bucket, Key):
+        if Bucket not in self.buckets:
+            raise ValueError("bucket doesn't exists")
+        bucket_obj = self.buckets[Bucket]
+        if Key not in bucket_obj:
+            error_response = {"Error": {"Code": "404"}}
+            error = botocore.exceptions.ClientError(error_response, "head object")
+            raise error
 
     def upload_file(self, Filename, Bucket, Key, ExtraArgs):
-        pass
+        if Bucket not in self.buckets:
+            raise ValueError("bucket doesn't exists")
+        bucket_object = self.buckets[Bucket]
+        if Key in bucket_object:
+            raise ValueError("file already present")
+        new_object = DummyStorageObject(name=Key, extra_args=ExtraArgs)
+        new_object.Filename = Filename
+        bucket_object[Key] = new_object
 
+    def get_object_acl(self, Bucket, Key):
+        if Bucket not in self.buckets:
+            raise ValueError("bucket doesn't exists")
+        bucket_object = self.buckets[Bucket]
+        if Key not in bucket_object:
+            raise ValueError("file doesn't found")
+        the_object = bucket_object[Key]
+        return the_object.acl
 
-def new_dummy_boto_client(*args, **kwargs):
-    return DummyBotoClient(*args, **kwargs)
+    def put_object_acl(self, Bucket, Key, ACL=None):
+        if Bucket not in self.buckets:
+            raise ValueError("bucket doesn't exists")
+        bucket_object = self.buckets[Bucket]
+        if Key not in bucket_object:
+            raise ValueError("file doesn't found")
+        the_object = bucket_object[Key]
+        if ACL != "public-read":
+            raise NotImplementedError
+        the_object.acl = {
+            "ResponseMetadata": {
+                "RequestId": "a-request-id",
+                "HTTPStatusCode": 200,
+            },
+            "Grants": [
+                {
+                    "Grantee": {
+                        "Type": "Group",
+                        "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+                    },
+                    "Permission": "READ",
+                },
+            ],
+        }
 
 
 @pytest.mark.filterwarnings("ignore:Exception ignored")
 def test_store_file(mocker: pytest_mock.MockerFixture) -> None:
     object_storage_url = "http://myobject-storage:myport/"
     bucket_name = "cads-catalogue"
-    json.dumps(object_storage.DOWNLOAD_POLICY_TEMPLATE) % {"bucket_name": bucket_name}
     storage_kws: dict[str, Any] = {
         "aws_access_key_id": "storage_user",
         "aws_secret_access_key": "storage_password",
@@ -68,127 +206,170 @@ def test_store_file(mocker: pytest_mock.MockerFixture) -> None:
         sha256 = hashlib.sha256(text).hexdigest()
     expected_url = f"{bucket_name}/licence-to-use-copernicus-products_{sha256}.pdf"
 
-    # run for a not existing file/not absolute path
+    # FIRST TEST: run for a not existing file/not absolute path
     use_client = DummyBotoClient("S3", endpoint_url=object_storage_url, **storage_kws)
     with pytest.raises(ValueError):
         object_storage.store_file(
             "not/existing.png", object_storage_url, use_client=use_client, **storage_kws
         )
 
-    # run without bucket_name nor subpath
-    with pytest.raises(ValueError):
-        # bucket name must exist if force is not used
-        object_storage.store_file(
-            file_path, object_storage_url, use_client=use_client, **storage_kws
-        )
-
-    # spies
+    # define spies
     head_bucket = mocker.spy(DummyBotoClient, "head_bucket")
     create_bucket = mocker.spy(DummyBotoClient, "create_bucket")
-    put_bucket_policy = mocker.spy(DummyBotoClient, "put_bucket_policy")
-    head_object = mocker.spy(DummyBotoClient, "head_object")
-    upload_file = mocker.spy(DummyBotoClient, "upload_file")
+    put_bucket_acl = mocker.spy(DummyBotoClient, "put_bucket_acl")
+    get_bucket_acl = mocker.spy(DummyBotoClient, "get_bucket_acl")
     get_bucket_cors = mocker.spy(DummyBotoClient, "get_bucket_cors")
     put_bucket_cors = mocker.spy(DummyBotoClient, "put_bucket_cors")
+    head_object = mocker.spy(DummyBotoClient, "head_object")
+    upload_file = mocker.spy(DummyBotoClient, "upload_file")
+    put_object_acl = mocker.spy(DummyBotoClient, "put_object_acl")
+    get_object_acl = mocker.spy(DummyBotoClient, "get_object_acl")
 
+    # SECOND TEST: upload first time on the default (not existing) bucket
     res = object_storage.store_file(
-        file_path, object_storage_url, force=True, use_client=use_client, **storage_kws
+        file_path, object_storage_url, use_client=use_client, **storage_kws
     )
-
     assert res == expected_url
-
-    # check spies
-    head_bucket.assert_called_once()
+    # check if the bucket exists
+    head_bucket.assert_called_once_with(use_client, Bucket="cads-catalogue")
+    # create the bucket
     create_bucket.assert_called_once_with(use_client, Bucket="cads-catalogue")
-    put_bucket_policy.assert_called_once_with(
+    # check bucket ACL
+    get_bucket_acl.assert_not_called()
+    # put bucket ACL
+    put_bucket_acl.assert_called_once_with(
+        use_client, ACL="public-read", Bucket="cads-catalogue"
+    )
+    # check bucket CORS
+    get_bucket_cors.assert_called_once_with(use_client, Bucket="cads-catalogue")
+    # put bucket CORS
+    put_bucket_cors.assert_called_once_with(
         use_client,
         Bucket="cads-catalogue",
-        Policy='{"Version": "2012-10-17", "Statement": '
-        '[{"Action": ["s3:GetBucketLocation", "s3:ListBucket"], '
-        '"Effect": "Allow", "Principal": {"AWS": ["*"]}, "Resource": '
-        '["arn:aws:s3:::cads-catalogue"]}, '
-        '{"Action": ["s3:GetObject", "s3:GetObjectVersion"], '
-        '"Effect": "Allow", "Principal": '
-        '{"AWS": ["*"]}, "Resource": ["arn:aws:s3:::cads-catalogue/*"]}]}',
+        CORSConfiguration=object_storage.DEFAULT_CORS_CONFIG,
     )
+    # check if the object exists
     head_object.assert_called_once_with(
         use_client,
-        Bucket=bucket_name,
+        Bucket="cads-catalogue",
         Key=f"licence-to-use-copernicus-products_{sha256}.pdf",
     )
+    # upload file
     upload_file.assert_called_once_with(
         use_client,
         Filename=file_path,
-        Bucket=bucket_name,
+        Bucket="cads-catalogue",
         Key=f"licence-to-use-copernicus-products_{sha256}.pdf",
-        ExtraArgs={"ContentType": "application/pdf"},
+        ExtraArgs={
+            "ContentType": utils.guess_type(file_path),
+            "ACL": "public-read",
+        },
     )
-    get_bucket_cors.assert_called_once_with(use_client, Bucket=bucket_name)
-    put_bucket_cors.assert_called_once_with(
-        use_client,
-        Bucket=bucket_name,
-        CORSConfiguration=object_storage.CORS_CONFIG,
-    )
+    # check object ACL
+    get_object_acl.assert_not_called()
+    # set object ACL
+    put_object_acl.assert_not_called()
 
     for spy in [
         head_bucket,
         create_bucket,
-        put_bucket_policy,
+        get_bucket_acl,
+        put_bucket_acl,
         head_object,
         upload_file,
         get_bucket_cors,
         put_bucket_cors,
+        get_object_acl,
+        put_object_acl,
     ]:
         spy.reset_mock()
 
-    # calling with a subpath and a bucket
+    # import pdb; pdb.set_trace()
+    # THIRD TEST: calling with a subpath and a (not existing) bucket
     subpath = "licences/mypath"
     bucket_name = "mybucket"
     expected_url = (
         f"{bucket_name}/licences/mypath/licence-to-use-copernicus-products_{sha256}.pdf"
     )
 
-    json.dumps(object_storage.DOWNLOAD_POLICY_TEMPLATE) % {"bucket_name": bucket_name}
     res = object_storage.store_file(
         file_path,
         object_storage_url,
         bucket_name,
         subpath,
         use_client=use_client,
-        force=True,
         **storage_kws,
     )
     assert res == expected_url
-
-    # check spies
-    head_bucket.assert_called_once()
+    head_bucket.assert_called_once_with(use_client, Bucket=bucket_name)
     create_bucket.assert_called_once_with(use_client, Bucket=bucket_name)
-    put_bucket_policy.assert_called_once_with(
-        use_client,
-        Bucket=bucket_name,
-        Policy='{"Version": "2012-10-17", "Statement": '
-        '[{"Action": ["s3:GetBucketLocation", "s3:ListBucket"], '
-        '"Effect": "Allow", "Principal": {"AWS": ["*"]}, '
-        '"Resource": ["arn:aws:s3:::mybucket"]}, '
-        '{"Action": ["s3:GetObject", "s3:GetObjectVersion"], '
-        '"Effect": "Allow", "Principal": '
-        '{"AWS": ["*"]}, "Resource": ["arn:aws:s3:::mybucket/*"]}]}',
-    )
-    head_object.assert_called_once_with(
-        use_client,
-        Bucket=bucket_name,
-        Key=f"licences/mypath/licence-to-use-copernicus-products_{sha256}.pdf",
-    )
-    upload_file.assert_called_once_with(
-        use_client,
-        Bucket=bucket_name,
-        Key=f"licences/mypath/licence-to-use-copernicus-products_{sha256}.pdf",
-        Filename=file_path,
-        ExtraArgs={"ContentType": "application/pdf"},
+    get_bucket_acl.assert_not_called()
+    put_bucket_acl.assert_called_once_with(
+        use_client, ACL="public-read", Bucket=bucket_name
     )
     get_bucket_cors.assert_called_once_with(use_client, Bucket=bucket_name)
     put_bucket_cors.assert_called_once_with(
         use_client,
         Bucket=bucket_name,
-        CORSConfiguration=object_storage.CORS_CONFIG,
+        CORSConfiguration=object_storage.DEFAULT_CORS_CONFIG,
     )
+    head_object.assert_called_once_with(
+        use_client,
+        Bucket=bucket_name,
+        Key=f"{subpath}/licence-to-use-copernicus-products_{sha256}.pdf",
+    )
+    upload_file.assert_called_once_with(
+        use_client,
+        Filename=file_path,
+        Bucket=bucket_name,
+        Key=f"{subpath}/licence-to-use-copernicus-products_{sha256}.pdf",
+        ExtraArgs={
+            "ContentType": utils.guess_type(file_path),
+            "ACL": "public-read",
+        },
+    )
+    get_object_acl.assert_not_called()
+    put_object_acl.assert_not_called()
+
+    for spy in [
+        head_bucket,
+        create_bucket,
+        get_bucket_acl,
+        put_bucket_acl,
+        head_object,
+        upload_file,
+        get_bucket_cors,
+        put_bucket_cors,
+        get_object_acl,
+        put_object_acl,
+    ]:
+        spy.reset_mock()
+
+    # FOURTH TEST: calling again the same upload (so bucket and file both exist)
+    res = object_storage.store_file(
+        file_path,
+        object_storage_url,
+        bucket_name,
+        subpath,
+        use_client=use_client,
+        **storage_kws,
+    )
+    assert res == expected_url
+    head_bucket.assert_called_once_with(use_client, Bucket=bucket_name)
+    create_bucket.assert_not_called()
+    get_bucket_acl.assert_called_once_with(use_client, Bucket=bucket_name)
+    put_bucket_acl.assert_not_called()
+    get_bucket_cors.assert_called_once_with(use_client, Bucket=bucket_name)
+    put_bucket_cors.assert_not_called()
+    head_object.assert_called_once_with(
+        use_client,
+        Bucket=bucket_name,
+        Key=f"{subpath}/licence-to-use-copernicus-products_{sha256}.pdf",
+    )
+    upload_file.assert_not_called()
+    get_object_acl.assert_called_once_with(
+        use_client,
+        Bucket=bucket_name,
+        Key=f"{subpath}/licence-to-use-copernicus-products_{sha256}.pdf",
+    )
+    put_object_acl.assert_not_called()

--- a/tests/test_20_licence_manager.py
+++ b/tests/test_20_licence_manager.py
@@ -58,7 +58,6 @@ def test_licence_sync(
     assert {
         "bucket_name": "mycatalogue_bucket",
         "subpath": "licences/CCI-data-policy-for-satellite-surface-radiation-budget",
-        "force": True,
         "aws_access_key_id": "admin1",
         "aws_secret_access_key": "secret1",
     } in [pm.kwargs for pm in patch.mock_calls]

--- a/tests/test_40_manager.py
+++ b/tests/test_40_manager.py
@@ -1734,7 +1734,6 @@ def test_resource_sync(
     assert {
         "bucket_name": "mycatalogue_bucket",
         "subpath": "resources/reanalysis-era5-land",
-        "force": True,
         "aws_access_key_id": "admin1",
         "aws_secret_access_key": "secret1",
     } in [pm.kwargs for pm in patch.mock_calls]

--- a/tests/test_90_entry_points.py
+++ b/tests/test_90_entry_points.py
@@ -195,7 +195,6 @@ def test_update_catalogue(
     assert (licence_path, object_storage_url) in [mp.args for mp in patch.mock_calls]
     assert {
         "bucket_name": bucket_name,
-        "force": True,
         "subpath": "licences/licence-to-use-copernicus-products",
         "aws_access_key_id": "storage_user",
         "aws_secret_access_key": "storage_password",
@@ -208,7 +207,6 @@ def test_update_catalogue(
             ),
             object_storage_url,
             bucket_name=bucket_name,
-            force=True,
             subpath="licences/licence-to-use-copernicus-products",
             **object_storage_kws,
         ),
@@ -221,7 +219,6 @@ def test_update_catalogue(
             ),
             object_storage_url,
             bucket_name=bucket_name,
-            force=True,
             subpath="resources/reanalysis-era5-land",
             **object_storage_kws,
         ),


### PR DESCRIPTION
According to [COPDS-1265](https://jira.ecmwf.int/browse/COPDS-1265),  object storage interface uses boto3. Buckets and files are checked and set read-only setting ACL "public-read" instead of applying policies (i.e. list of permissions). It was applied also a base refactoring of the interface to the object storage.