### PR TITLE
fix: layout.json doesn't remove placeholders

### DIFF
--- a/cads_catalogue/layout_manager.py
+++ b/cads_catalogue/layout_manager.py
@@ -278,12 +278,12 @@ def transform_cim_blocks(layout_data: dict[str, Any], cim_layout_path: str):
     -------
     dict: dictionary of layout_data modified
     """
-    if not os.path.exists(cim_layout_path):
-        return layout_data
     remove_tab = True
     remove_aside = True
-    with open(cim_layout_path) as fp:
-        cim_layout_data = json.load(fp)
+    cim_layout_data = dict()
+    if os.path.exists(cim_layout_path):
+        with open(cim_layout_path) as fp:
+            cim_layout_data = json.load(fp)
     qa_tab = cim_layout_data.get("quality_assurance_tab", {})
     qa_tab_blocks = qa_tab.get("blocks")
     if qa_tab_blocks is not None:

--- a/tests/test_30_layout_manager.py
+++ b/tests/test_30_layout_manager.py
@@ -678,7 +678,7 @@ def test_transform_cim_blocks(tmpdir):
     )
     assert new_layout_data == layout_data
 
-    # test case 2: not existing cim layout, existing only QA_tab section -> no change of input layout_data
+    # test case 2: not existing cim layout, existing only QA_tab section -> remove placeholder
     qa_tab_section = {
         "title": "Quality assurance, or whatever",
         "id": "quality_assurance_tab",
@@ -692,9 +692,10 @@ def test_transform_cim_blocks(tmpdir):
     new_layout_data = layout_manager.transform_cim_blocks(
         layout_data, cim_layout_path=cim_layout_path
     )
-    assert new_layout_data == layout_data
-
-    # test case 3: not existing cim layout, existing only QA_aside block -> no change of input layout_data
+    assert new_layout_data == create_layout_for_test(
+        layout_path, sections=test_sections_1, aside=test_aside_1
+    )
+    # test case 3: not existing cim layout, existing only QA_aside block -> remove placeholder
     new_aside_block = {
         "title": "QA or whatever",
         "id": "quality_assurance_aside",
@@ -707,13 +708,20 @@ def test_transform_cim_blocks(tmpdir):
         "title": "a new title",
         "type": "a new type",
     }
+    expected_aside_2 = {
+        "blocks": test_aside_1["blocks"],
+        "title": "a new title",
+        "type": "a new type",
+    }
     layout_data = create_layout_for_test(
         layout_path, sections=test_sections_1, aside=test_aside_2
     )
     new_layout_data = layout_manager.transform_cim_blocks(
         layout_data, cim_layout_path=cim_layout_path
     )
-    assert new_layout_data == layout_data
+    assert new_layout_data == create_layout_for_test(
+        layout_path, sections=test_sections_1, aside=expected_aside_2
+    )
 
     # test case 4: existing cim layout, not existing QA section/aside on layout
     # -> no change of input layout_data


### PR DESCRIPTION
In case of dataset not found in "cads-forms-cim-json" -> quality_assurance placeholders must be removed from cads-forms-json's layout.json (if present)