### PR TITLE
bugfix: abstract parsing 

### DIFF
--- a/cads_catalogue/utils.py
+++ b/cads_catalogue/utils.py
@@ -170,6 +170,7 @@ def normalize_abstract(text: str) -> str:
     replacer_map = {"sup": superscript_text, "sub": subscript_text}
     parser = TagReplacer(replacer_map)
     parser.feed(text)
+    parser.close()
     return parser.output_text
 
 


### PR DESCRIPTION
Reading of the "abstract" field in metadata.json was wrong in case of last word contains the '&' character.