### PR TITLE
disabling optimization to avoid perpetual force update

### DIFF
--- a/cads_catalogue/entry_points.py
+++ b/cads_catalogue/entry_points.py
@@ -381,10 +381,6 @@ def update_catalogue(
         logger.info("db update of relationships between datasets")
         manager.update_related_resources(session)
         # store information of current input status
-        for override_resource_uid in current_override_md.copy():
-            if override_resource_uid not in involved_resource_uids:
-                # do not store not used override information
-                del current_override_md[override_resource_uid]
         status_info: dict[str, Any] = dict()
         if licences_processed:
             # (all) licences have been effectively processed


### PR DESCRIPTION
Micro-optimization of corner cases,  using an 'override' file, may impose catalogue manager to use the option '--force' automatically every time. This PR disables this optimization to avoid this risk.