### PR TITLE
management of html blocks in layout.json

### DIFF
--- a/cads_catalogue/layout_manager.py
+++ b/cads_catalogue/layout_manager.py
@@ -513,7 +513,7 @@ def transform_html_blocks(
     sections = body_main.get("sections", [])
     for i, section in enumerate(copy.deepcopy(sections)):
         sections[i] = manage_html_block_in_section(section, layout_folder_path)
-    # search all the html blocks inside body/aside:
+    # search all html blocks inside body/aside:
     aside_section = body.get("aside", {})
     if aside_section:
         new_data["body"]["aside"] = manage_html_block_in_section(

--- a/cads_catalogue/layout_manager.py
+++ b/cads_catalogue/layout_manager.py
@@ -442,6 +442,86 @@ def transform_cim_blocks(
     return new_data
 
 
+def manage_html_block_in_section(section, layout_folder_path):
+    """
+    Look for html blocks and modify accordingly if it has references to external file.
+
+    Parameters
+    ----------
+    section: section of layout.json data
+    layout_folder_path: path to the folder containing layout file
+    """
+    new_section = copy.deepcopy(section)
+    blocks = new_section.get("blocks", [])
+    for i, block in enumerate(copy.deepcopy(blocks)):
+        if block.get("type") == "html":
+            block_id = block["id"]
+            if "content_source" in block:
+                content_source = block["content_source"]
+                source_path = os.path.abspath(
+                    os.path.join(layout_folder_path, content_source)
+                )
+                is_content_in_block = "content" in block
+                if os.path.isfile(source_path):
+                    # replacing/overwrite
+                    if is_content_in_block:
+                        # overwrite
+                        msg = (
+                            f"found html block {block_id} with both 'content' and 'content_source': "
+                            f"applying overwrite"
+                        )
+                        logger.warning(msg)
+                    with open(source_path) as fp:
+                        blocks[i]["content"] = fp.read()
+                    del blocks[i]["content_source"]
+                elif is_content_in_block:
+                    # default
+                    msg = (
+                        f"found html block {block_id} with both 'content' and 'content_source': "
+                        f"applying default (not found source {content_source})"
+                    )
+                    logger.warning(msg)
+                    del blocks[i]["content_source"]
+                else:
+                    # error
+                    raise ValueError(
+                        f"not found referred {content_source} in html block {block_id}"
+                    )
+        elif block.get("type") in ("section", "accordion"):
+            blocks[i] = manage_html_block_in_section(block, layout_folder_path)
+    return new_section
+
+
+def transform_html_blocks(
+    layout_data: dict[str, Any], layout_folder_path: str | pathlib.Path
+):
+    """Transform layout.json data replacing html blocks with referred external files.
+
+    Parameters
+    ----------
+    layout_data: data of the layout.json to transform
+    layout_folder_path: path to the folder containing layout file
+
+    Returns
+    -------
+    dict: dictionary of layout_data modified
+    """
+    new_data = copy.deepcopy(layout_data)
+    # search all html blocks inside body/main/sections:
+    body = new_data.get("body", {})
+    body_main = body.get("main", {})
+    sections = body_main.get("sections", [])
+    for i, section in enumerate(copy.deepcopy(sections)):
+        sections[i] = manage_html_block_in_section(section, layout_folder_path)
+    # search all the html blocks inside body/aside:
+    aside_section = body.get("aside", {})
+    if aside_section:
+        new_data["body"]["aside"] = manage_html_block_in_section(
+            aside_section, layout_folder_path
+        )
+    return new_data
+
+
 def has_section_id(layout_data: dict[str, Any], section_id: str):
     """
     Return True if layout has section id `section_id`.
@@ -468,6 +548,7 @@ def store_layout_by_data(
     layout_data: dict[str, Any],
     resource: dict[str, Any],
     storage_settings: config.ObjectStorageSettings,
+    subpath: str | None = None,
 ) -> str:
     """
     Store a layout.json in the object storage providing its json data.
@@ -477,6 +558,7 @@ def store_layout_by_data(
     layout_data: data of the layout.json to store
     resource: resource dictionary (as returned by `load_resource_from_folder`)
     storage_settings: object with settings to access the object storage
+    subpath: bucket subpath, otherwise resources/<resource_uid> is assumed
 
     Returns
     -------
@@ -484,7 +566,8 @@ def store_layout_by_data(
     """
     # upload of modified layout.json
     tempdir_path = tempfile.mkdtemp()
-    subpath = os.path.join("resources", resource["resource_uid"])
+    if not subpath:
+        subpath = os.path.join("resources", resource["resource_uid"])
     layout_temp_path = os.path.join(tempdir_path, "layout.json")
     with open(layout_temp_path, "w") as fp:
         json.dump(layout_data, fp, indent=2)
@@ -533,6 +616,7 @@ def transform_layout(
     cim_layout_path = os.path.join(
         cim_folder_path, resource["resource_uid"], "quality_assurance.layout.json"
     )
+    layout_data = transform_html_blocks(layout_data, resource_folder_path)
     layout_data = transform_cim_blocks(
         layout_data, cim_layout_path, resource["qa_flag"]
     )

--- a/tests/data/cads-contents-json/how-to-api/layout.json
+++ b/tests/data/cads-contents-json/how-to-api/layout.json
@@ -10,7 +10,8 @@
             {
               "id": "page-content",
               "type": "html",
-              "content": "<div>TODO</div>"
+              "content": "<div>TODO</div>",
+              "content_source": "../html_block.html"
             }
           ]
         }

--- a/tests/data/cads-contents-json/html_block.html
+++ b/tests/data/cads-contents-json/html_block.html
@@ -1,0 +1,1 @@
+<p>this is a content of a html block</p>

--- a/tests/test_15_contents.py
+++ b/tests/test_15_contents.py
@@ -216,7 +216,6 @@ def test_content_sync(
     ]
     content1["publication_date"] = "2021-03-18T11:02:31Z"
     content1["title"] = "new title"
-    content1["layout"] = os.path.join(content_folder, "cica-overview.png")
     with session_obj() as session:
         # db is not empty: update a content
         db_content2 = contents.content_sync(session, content1, storage_settings)
@@ -253,8 +252,6 @@ def test_content_sync(
         for key, value in content1.items():
             if key in ("publication_date", "content_update"):
                 value = datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")  # type: ignore
-            elif key in ("layout",):
-                value = "an url"
             elif key == "keywords":
                 continue
             assert getattr(db_content2, key) == value

--- a/tests/test_30_layout_manager.py
+++ b/tests/test_30_layout_manager.py
@@ -916,3 +916,107 @@ def test_transform_licence_acceptance_blocks(session_obj: sa.orm.sessionmaker):
         expected_layout_data = json.load(fp)
     assert out_layout_data == expected_layout_data
     session.close()
+
+
+def build_layout_data(blocks):
+    """For testing transform_html_blocks."""
+    layout_data = {
+        "title": "CDSAPI setup",
+        "description": "Access the full data store catalogue, with search and availability features",
+        "body": {
+            "main": {
+                "sections": [
+                    {
+                        "id": "main",
+                        "blocks": blocks,
+                    }
+                ]
+            }
+        },
+    }
+    return layout_data
+
+
+def test_transform_html_blocks():
+    # note: layout_folder_path is the reference for relative path of the html content source
+    layout_folder_path = os.path.join(TESTDATA_PATH, "cads-contents-json", "how-to-api")
+    with open(
+        os.path.join(TESTDATA_PATH, "cads-contents-json", "html_block.html")
+    ) as fp:
+        html_block_content = fp.read()
+    thumb_block = {
+        "id": "test_block",
+        "type": "thumb-markdown",
+        "content": "EAC4",
+    }
+    html_block_no_change = {
+        "id": "test_block",
+        "type": "html",
+        "content": "<p>this must be static</p>",
+    }
+    html_block_replace = {
+        "id": "test_block",
+        "type": "html",
+        "content_source": "../html_block.html",
+    }
+    html_block_overwrite = {
+        "id": "test_block",
+        "type": "html",
+        "content_source": "../html_block.html",
+        "content": "<div>to be overriden</div>",
+    }
+    html_block_default = {
+        "id": "test_block",
+        "type": "html",
+        "content_source": "../not_exist.html",
+        "content": "<div>to be overriden</div>",
+    }
+    html_block_broken = {
+        "id": "test_block",
+        "type": "html",
+        "content_source": "../not_exist.html",
+    }
+    exp_html_block_replaced = {
+        "id": "test_block",
+        "type": "html",
+        "content": html_block_content,
+    }
+    exp_html_block_default = {
+        "id": "test_block",
+        "type": "html",
+        "content": "<div>to be overriden</div>",
+    }
+    # no change
+    in_layout_data = build_layout_data([thumb_block, html_block_no_change, thumb_block])
+    out_layout_data = layout_manager.transform_html_blocks(
+        in_layout_data, layout_folder_path
+    )
+    assert out_layout_data == in_layout_data
+    # replace
+    in_layout_data = build_layout_data([thumb_block, html_block_replace, thumb_block])
+    out_layout_data = layout_manager.transform_html_blocks(
+        in_layout_data, layout_folder_path
+    )
+    assert out_layout_data == build_layout_data(
+        [thumb_block, exp_html_block_replaced, thumb_block]
+    )
+    # overwrite
+    in_layout_data = build_layout_data([thumb_block, html_block_overwrite, thumb_block])
+    out_layout_data = layout_manager.transform_html_blocks(
+        in_layout_data, layout_folder_path
+    )
+    assert out_layout_data == build_layout_data(
+        [thumb_block, exp_html_block_replaced, thumb_block]
+    )
+    # default
+    in_layout_data = build_layout_data([thumb_block, html_block_default, thumb_block])
+    out_layout_data = layout_manager.transform_html_blocks(
+        in_layout_data, layout_folder_path
+    )
+    assert out_layout_data == build_layout_data(
+        [thumb_block, exp_html_block_default, thumb_block]
+    )
+    # broken
+    in_layout_data = build_layout_data([thumb_block, html_block_broken, thumb_block])
+    with pytest.raises(ValueError):
+        layout_manager.transform_html_blocks(in_layout_data, layout_folder_path)

--- a/tests/test_90_entry_points.py
+++ b/tests/test_90_entry_points.py
@@ -640,12 +640,12 @@ def test_update_catalogue(
             os.path.join(
                 TESTDATA_PATH,
                 "cads-contents-json",
-                "how-to-api",
-                "layout.json",
+                "copernicus-interactive-climates-atlas",
+                "cica-overview.png",
             ),
             object_storage_url,
             bucket_name=bucket_name,
-            subpath="contents/ads/page/how-to-api",
+            subpath="contents/cds/application/copernicus-interactive-climates-atlas",
             **object_storage_kws,
         ),
     ]


### PR DESCRIPTION
This PR manages HTML blocks inside layout files, in the context of loading data from cads-forms-json and from cads-contents-json, according to specifications of [COPDS-1635 html blocks](https://jira.ecmwf.int/browse/COPDS-1635).
