### PR TITLE
COPDS-1672: Template-like json for catalogue manager

### DIFF
--- a/alembic/versions/e5875ac4a047_save_contents_configuration.py
+++ b/alembic/versions/e5875ac4a047_save_contents_configuration.py
@@ -12,8 +12,8 @@ from sqlalchemy.dialects import postgresql as dialect_postgresql
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = 'e5875ac4a047'
-down_revision = '694fde86c48c'
+revision = "e5875ac4a047"
+down_revision = "694fde86c48c"
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/e5875ac4a047_save_contents_configuration.py
+++ b/alembic/versions/e5875ac4a047_save_contents_configuration.py
@@ -1,0 +1,29 @@
+"""save contents configuration.
+
+Revision ID: e5875ac4a047
+Revises: 694fde86c48c
+Create Date: 2024-12-05 14:20:53.059624
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as dialect_postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'e5875ac4a047'
+down_revision = '694fde86c48c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "catalogue_updates",
+        sa.Column("contents_config", dialect_postgresql.JSONB, default={}),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("catalogue_updates", "contents_config")

--- a/cads_catalogue/contents.py
+++ b/cads_catalogue/contents.py
@@ -126,12 +126,12 @@ def load_content_folder(
         global_context = dict()
     metadata_file_path = os.path.join(content_folder, "metadata.json")
     with open(metadata_file_path) as fp:
-        data = json.load(fp)
+        data_raw = json.load(fp)
     ret_value = []
-    for site in data["site"]:
+    for site in data_raw["site"][:]:
         site_context = global_context.get("default", dict())
-        site_context.update(global_context.get("site", dict()))
-        data = utils.dict_render(data, site_context)
+        site_context.update(global_context.get(site, dict()))
+        data = utils.dict_render(data_raw, site_context)
         metadata = {
             "site": site,
             "type": data["resource_type"],

--- a/cads_catalogue/database.py
+++ b/cads_catalogue/database.py
@@ -67,6 +67,7 @@ class CatalogueUpdate(BaseModel):
     cim_repo_commit = sa.Column(sa.String)
     content_repo_commit = sa.Column(sa.String)
     override_md = sa.Column(dialect_postgresql.JSONB, default={})
+    contents_config = sa.Column(dialect_postgresql.JSONB, default={})
 
 
 class Content(BaseModel):

--- a/cads_catalogue/entry_points.py
+++ b/cads_catalogue/entry_points.py
@@ -401,6 +401,7 @@ def update_catalogue(
                     session,
                     contents_folder_path,  # type: ignore
                     storage_settings,
+                    # TODO: add here yaml config for contents templating
                 )
         # delete orphans
         if delete_orphans:  # -> always false if filtering is active

--- a/cads_catalogue/entry_points.py
+++ b/cads_catalogue/entry_points.py
@@ -177,6 +177,7 @@ def update_catalogue(
     contents_folder_path: Optional[
         str
     ] = None,  # os.path.join(PACKAGE_DIR, "cads-contents-json"),
+    contents_config_path: Optional[str] = None,
     connection_string: Optional[str] = None,
     force: bool = False,
     delete_orphans: bool = True,
@@ -197,6 +198,7 @@ def update_catalogue(
     :param licences_folder_path: folder containing metadata files for licences (i.e. cads-licences)
     :param cim_folder_path: str = folder containing CIM Quality Assessment layouts (i.e. cads-forms-cim-json)
     :param contents_folder_path = folder containing metadata files for contents (i.e. cads-contents-json)
+    :param contents_config_path = path of the file yaml containing template variables for contents
     :param connection_string: something like 'postgresql://user:password@netloc:port/dbname'
     :param force: if True, run update regardless input folders has no changes from last update (default False)
     :param delete_orphans: if True, delete resources/licences not involved. False if using include/exclude
@@ -401,7 +403,7 @@ def update_catalogue(
                     session,
                     contents_folder_path,  # type: ignore
                     storage_settings,
-                    # TODO: add here yaml config for contents templating
+                    yaml_path=contents_config_path,
                 )
         # delete orphans
         if delete_orphans:  # -> always false if filtering is active

--- a/tests/data/cads-contents-json/how-to-api-templated/layout.json
+++ b/tests/data/cads-contents-json/how-to-api-templated/layout.json
@@ -1,0 +1,21 @@
+{
+  "title": "${siteSlug}API setup",
+  "description": "Access the full data store catalogue of ${siteName}, with search and availability features. Global prop: ${global_prop}",
+  "body": {
+    "main": {
+      "sections": [
+        {
+          "id": "main",
+          "blocks": [
+            {
+              "id": "page-content",
+              "type": "html",
+              "content": "<div>TODO</div>",
+              "content_source": "../html_block.html"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/data/cads-contents-json/how-to-api-templated/metadata.json
+++ b/tests/data/cads-contents-json/how-to-api-templated/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "how-to-api-templated",
+  "resource_type": "page",
+  "title": "${siteSlug} API setup",
+  "abstract": "Access ${global_prop} items of ${siteName} catalogue, with search and availability features",
+  "site": ["ads"],
+  "publication_date": "2024-09-13T10:01:50Z",
+  "update_date": "2024-09-16T02:10:22Z",
+  "layout": "./layout.json"
+}

--- a/tests/data/cads-contents-json/html_block.html
+++ b/tests/data/cads-contents-json/html_block.html
@@ -1,1 +1,2 @@
 <p>this is a content of a html block</p>
+<p>${apiSnippet}</p>

--- a/tests/data/cads-contents-json/template_config.yaml
+++ b/tests/data/cads-contents-json/template_config.yaml
@@ -1,0 +1,17 @@
+default:
+  apiSnippet: |
+    import something
+    this_is_a_default_snippet
+  global_prop: 33
+cds:
+  siteSlug: CDS
+  siteName: Climate Data Store
+  apiSnippet: |
+    import cds_stuff
+    this_is_cds_snippet
+ads:
+  siteSlug: ADS
+  siteName: ADS Data Store
+  apiSnippet: |
+    import ads_stuff
+    this_is_ads_snippet

--- a/tests/test_90_entry_points.py
+++ b/tests/test_90_entry_points.py
@@ -617,9 +617,9 @@ def test_update_catalogue(
     _update_catalogue_messages.assert_called_once()
     _update_catalogue_messages.reset_mock()
     # check object storage calls
-    assert _store_file.call_count == 8
+    assert _store_file.call_count == 9
     #     # overview.png * 3 = 3 (one from contents)
-    #     # layout.json * 3 = 3 (2 from contents)
+    #     # layout.json * 4 = 4 (3 from contents)
     #     # form.json = 1
     #     # constraints.json = 1
     #     # check object storage calls
@@ -683,15 +683,16 @@ def test_update_catalogue(
             )
         ]
         sql2 = "select slug, title, site, type from contents order by site, type, slug"
-        assert session.execute(sa.text(sql2)).all() == [
-            ("how-to-api", "CDSAPI setup", "ads", "page"),
+        assert sorted(session.execute(sa.text(sql2)).all()) == [
             (
                 "copernicus-interactive-climates-atlas",
                 "Copernicus Interactive Climate Atlas",
                 "cds",
                 "application",
             ),
+            ("how-to-api", "CDSAPI setup", "ads", "page"),
             ("how-to-api", "CDSAPI setup", "cds", "page"),
+            ("how-to-api-templated", "${siteSlug} API setup", "ads", "page"),
         ]
 
     # 3.bis repeat last run -------------------------------------------------------------
@@ -762,7 +763,7 @@ def test_update_catalogue(
         )
         assert (
             session.execute(sa.text("select count(*) from contents")).scalars().one()
-            == 3
+            == 4
         )
         sql = (
             "select catalogue_repo_commit, metadata_repo_commit, licence_repo_commit, "
@@ -847,8 +848,8 @@ def test_update_catalogue(
     # check load of contents is run (it's forced)
     _update_catalogue_contents.assert_called_once()
     _update_catalogue_contents.reset_mock()
-    # check object storage called for 1 dataset, 4 licences and 3 contents (5 + 4*2 + 3)
-    assert _store_file.call_count == 16
+    # check object storage called for 1 dataset, 4 licences and 4 contents (5 + 4*2 + 4)
+    assert _store_file.call_count == 17
     _store_file.reset_mock()
 
     # check db changes are reset
@@ -1215,13 +1216,13 @@ def test_update_catalogue(
     _update_catalogue_contents.assert_called_once()
     _update_catalogue_contents.reset_mock()
     # check object storage called
-    assert _store_file.call_count == 51
+    assert _store_file.call_count == 52
     #     # num.licences * 2 = 8
     #     # num.datasets overview.png * 2 = 16
     #     # num.datasets layout.json = 8
     #     # num.datasets form.json = 8
     #     # num.datasets constraints.json = 8
-    #     # num.contents = 3
+    #     # num.contents = 4
     _store_file.reset_mock()
 
     # check db content
@@ -1342,13 +1343,13 @@ def test_update_catalogue(
     _update_catalogue_contents.assert_called_once()
     _update_catalogue_contents.reset_mock()
     # check object storage called
-    assert _store_file.call_count == 51
+    assert _store_file.call_count == 52
     #     # num.licences * 2 = 8
     #     # num.datasets overview.png * 2 = 16
     #     # num.datasets layout.json = 8
     #     # num.datasets form.json = 8
     #     # num.datasets constraints.json = 8
-    #     # num.contents = 3
+    #     # num.contents = 4
     _store_file.reset_mock()
 
     # check db content


### PR DESCRIPTION
Added option `--contents-config-path` to the catalogue manager entry point, in order to use variables inside contents layout and metadata. This path is a yaml file. 
Variables are rendered if defined inside brace brackets: ${MYVAR}