### PR TITLE
catalogue manager stores a boolean flag to hide contents

### DIFF
--- a/alembic/versions/6ac5a2abf5f5_hidden_contents_bool.py
+++ b/alembic/versions/6ac5a2abf5f5_hidden_contents_bool.py
@@ -1,0 +1,29 @@
+"""add boolean flag to hidden contents.
+
+Revision ID: 6ac5a2abf5f5
+Revises: e5875ac4a047
+Create Date: 2024-12-17 10:26:33.649562
+
+"""
+
+import sqlalchemy as sa
+
+import alembic
+
+# revision identifiers, used by Alembic.
+revision = "6ac5a2abf5f5"
+down_revision = "e5875ac4a047"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    alembic.op.add_column(
+        "contents", sa.Column("hidden", sa.Boolean, default=True, nullable=True)
+    )
+    alembic.op.execute("UPDATE contents SET hidden = FALSE")
+    alembic.op.alter_column("contents", "hidden", nullable=False)
+
+
+def downgrade() -> None:
+    alembic.op.drop_column("contents", "hidden")

--- a/cads_catalogue/contents.py
+++ b/cads_catalogue/contents.py
@@ -143,6 +143,7 @@ def load_content_folder(
             "link": data.get("link"),
             "keywords": data.get("keywords", []),
             "data": data.get("data"),
+            "hidden": data.get("hidden", False),
             # managed below:
             # "image": None,
             # "layout": None,

--- a/cads_catalogue/database.py
+++ b/cads_catalogue/database.py
@@ -81,6 +81,7 @@ class Content(BaseModel):
     content_update = sa.Column(sa.TIMESTAMP, nullable=False)
     data = sa.Column(dialect_postgresql.JSONB)
     description = sa.Column(sa.String, nullable=False)
+    hidden = sa.Column(sa.Boolean, default=False, nullable=False)
     image = sa.Column(sa.String)
     layout = sa.Column(sa.String)
     link = sa.Column(sa.String)

--- a/tests/data/cads-contents-json/how-to-api-templated/metadata.json
+++ b/tests/data/cads-contents-json/how-to-api-templated/metadata.json
@@ -6,5 +6,6 @@
   "site": ["ads"],
   "publication_date": "2024-09-13T10:01:50Z",
   "update_date": "2024-09-16T02:10:22Z",
-  "layout": "./layout.json"
+  "layout": "./layout.json",
+  "hidden": false
 }

--- a/tests/data/cads-contents-json/how-to-api/metadata.json
+++ b/tests/data/cads-contents-json/how-to-api/metadata.json
@@ -6,5 +6,6 @@
   "site": ["cds", "ads"],
   "publication_date": "2024-09-13T10:01:50Z",
   "update_date": "2024-09-16T02:10:22Z",
-  "layout": "./layout.json"
+  "layout": "./layout.json",
+  "hidden": true
 }

--- a/tests/test_15_contents.py
+++ b/tests/test_15_contents.py
@@ -46,6 +46,7 @@ def test_load_content_folder() -> None:
         {
             "slug": "copernicus-interactive-climates-atlas",
             "publication_date": "2024-09-13T00:00:00Z",
+            "hidden": False,
             "description": "The Copernicus Interactive Climate Atlas provides graphical "
             "information about recent past trends and future changes "
             "(for different scenarios and global warming levels)",
@@ -83,6 +84,7 @@ def test_load_content_folder() -> None:
         {
             "slug": "how-to-api-templated",
             "publication_date": "2024-09-13T10:01:50Z",
+            "hidden": False,
             "description": "Access 33 items of ADS Data Store catalogue, "
             "with search and availability features",
             "image": None,
@@ -110,6 +112,7 @@ def test_load_contents() -> None:
         {
             "slug": "copernicus-interactive-climates-atlas",
             "publication_date": "2024-09-13T00:00:00Z",
+            "hidden": False,
             "description": "The Copernicus Interactive Climate Atlas provides graphical "
             "information about recent past trends and future changes "
             "(for different scenarios and global warming levels)",
@@ -142,6 +145,7 @@ def test_load_contents() -> None:
         {
             "slug": "how-to-api",
             "publication_date": "2024-09-13T10:01:50Z",
+            "hidden": True,
             "description": "Access the full data store catalogue, "
             "with search and availability features",
             "image": None,
@@ -157,6 +161,7 @@ def test_load_contents() -> None:
         {
             "slug": "how-to-api",
             "publication_date": "2024-09-13T10:01:50Z",
+            "hidden": True,
             "description": "Access the full data store catalogue, "
             "with search and availability features",
             "image": None,
@@ -172,6 +177,7 @@ def test_load_contents() -> None:
         {
             "slug": "how-to-api-templated",
             "publication_date": "2024-09-13T10:01:50Z",
+            "hidden": False,
             "description": "Access 33 items of ADS Data Store catalogue, "
             "with search and availability features",
             "image": None,
@@ -214,6 +220,7 @@ def test_content_sync(
     content1 = {
         "slug": "copernicus-interactive-climates-atlas",
         "publication_date": "2024-09-13T00:00:00Z",
+        "hidden": True,
         "description": "The Copernicus Interactive Climate Atlas provides graphical "
         "information about recent past trends and future changes "
         "(for different scenarios and global warming levels)",


### PR DESCRIPTION
Reference: https://jira.ecmwf.int/browse/COPDS-2231

metadata.json inside cads-contents-json can have a new "hidden" boolean flag (default value is False):
```
{
  "id": "copernicus-interactive-climates-atlas",
  "resource_type": "application",
  "hidden": true,
...
} 
```
The value is stored by the catalogue manager in a boolean column inside the table contents (required, default False).